### PR TITLE
Update link to balsamiq.com

### DIFF
--- a/assignment-webproposal.html
+++ b/assignment-webproposal.html
@@ -248,7 +248,7 @@
       <li>Many drawing, sketching, and image editing apps can be helpful in making sketches.</li>
       <li>Google Image Search can help you find images to incorporate in your designs.</li>
       <li>There are several free tools available especially for creating mockups of web and mobile apps.</li>
-      <li>Some online web design tools (for example, <a href="balsamiq.com">balsamiq</a>) have free trials.</li>
+      <li>Some online web design tools (for example, <a href="http://www.balsamiq.com">balsamiq</a>) have free trials.</li>
     </ul>
 
     <h2>Evaluation</h2>


### PR DESCRIPTION
The link to balsamiq.com is relative instead of absolute, and thus leads to the invalid page: http://c4q.github.io/accesscode-apply-jsworkshop/balsamiq.com
I changed the link to http://www.balsamiq.com. 
